### PR TITLE
Test tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ pdl-core
 xs-cookbook
 META.yml
 MYMETA.yml
-
+pp-*.c

--- a/t/04_viterbi.t
+++ b/t/04_viterbi.t
@@ -60,4 +60,3 @@ pdlok("o=[0,1,0]: path", $path, pdl(long, [[0,0,0],[0,1,1]]));
 
 print "\n";
 # end of t/XX_yyyy.t
-

--- a/t/common.plt
+++ b/t/common.plt
@@ -99,7 +99,8 @@ sub pdlapprox {
   isok($label,
        defined($got) && defined($want)
        && cmp_dims($got,$want)
-       && all(matchpdla($want,$got,$eps)));
+       && all(matchpdla($want,$got,$eps)))
+    or diag "got=$got\nwant=$want";
 }
 
 # pdlapprox_nodims($label, $got, $want, $eps=1e-5)
@@ -113,7 +114,6 @@ sub pdlapprox_nodims {
        #&& cmp_dims($got,$want)
        && all(matchpdla($want,$got,$eps)));
 }
-
 
 print "loaded ", __FILE__, "\n";
 

--- a/t/common.plt
+++ b/t/common.plt
@@ -5,6 +5,7 @@ BEGIN { $| = 1; }
 
 # isok($label,@_) -- prints helpful label
 sub isok {
+  local $Test::Builder::Level = $Test::Builder::Level + 2;
   my $label = shift;
   if (@_==1) {
     ok($_[0],$label);
@@ -117,4 +118,3 @@ sub pdlapprox_nodims {
 print "loaded ", __FILE__, "\n";
 
 1;
-


### PR DESCRIPTION
I was taking a look at this due to @zmughal's amazing downstream-testing catching my boo-boo in breaking `$x(n=>t+1)` in PDL (which remarkably, isn't used anywhere in that distro, though there's a test for it now). These changes seem like they might be of value (especially making `isok` not just repeatedly complain about line 10 of the common file). They might even be applicable across the Bryan-verse :-)