### PR TITLE
Output-only operation cannot be Inplace

### DIFF
--- a/HMM.pd
+++ b/HMM.pd
@@ -182,7 +182,6 @@ EOPM
 ## logzero(): near approximation of log(0)
 pp_def('logzero',
        Pars => 'float+ [o]a()',
-       Inplace=>['a'], ##-- can run inplace on a()
        Code => '$a() = LOG_ZERO;',
        CopyBadStatusCode =>
 	  (" if ( \$ISPDLSTATEBAD(a) ) PDL->${propagate_badflag}(a,0);"


### PR DESCRIPTION
Sorry for the flurry of changes!

I was adjusting how `Inplace` works, and this was the only downstream distro that got broken by it. You give `Inplace` for an operation that only has an output ndarray. That isn't meaningful, but *does* break with the adjustment.