### PR TITLE
use GenericTypes to require floating-point inputs

### DIFF
--- a/HMM.pd
+++ b/HMM.pd
@@ -622,17 +622,17 @@ pp_def
 ('hmmexpect',
  GenericTypes => $FLOAT_TYPES,
  Pars => join(" ",
-	      qw(a(N,N);
-		 b(N,M);
-		 pi(N);
-		 omega(N);
-		 o(T);
-		 alpha(N,T);
-		 beta(N,T);),
-	      qw([o]ea(N,N);
-		 [o]eb(N,M);
-		 [o]epi(N);
-		 [o]eomega(N);)),
+              qw(a(N,N);
+                 b(N,M);
+                 pi(N);
+                 omega(N);
+                 o(T);
+                 alpha(N,T);
+                 beta(N,T);),
+              qw([o]ea(N,N);
+                 [o]eb(N,M);
+                 [o]epi(N);
+                 [o]eomega(N);)),
  Code =>
 ('
  int i,j,t;
@@ -697,18 +697,18 @@ pp_def
 ('hmmexpectq',
  GenericTypes => $FLOAT_TYPES,
  Pars => join(" ",
-	      qw(a(N,N);
-		 b(N,M);
-		 pi(N);
-		 omega(N);),
-	      qw(o(T);
-		 oq(Q,T);),
-	      qw(alphaq(Q,T);
-		 betaq(Q,T);),
-	      qw([o]ea(N,N);
-		 [o]eb(N,M);
-		 [o]epi(N);
-		 [o]eomega(N);)),
+              qw(a(N,N);
+                 b(N,M);
+                 pi(N);
+                 omega(N);),
+              qw(o(T);
+                 oq(Q,T);),
+              qw(alphaq(Q,T);
+                 betaq(Q,T);),
+              qw([o]ea(N,N);
+                 [o]eb(N,M);
+                 [o]epi(N);
+                 [o]eomega(N);)),
  Code =>
 ('
  int i,j,t, qi,qj;
@@ -841,13 +841,13 @@ EOPM
 pp_def
 ('hmmviterbi',
  Pars => join(" ",
-	      qw(a(N,N);
-             b(N,M);
-		 pi(N);),
-	      #qw(omega(N);),
-	      qw(o(T);
-		   [o]delta(N,T);),
-	      'int [o]psi(N,T)'),
+              qw(a(N,N);
+                 b(N,M);
+                 pi(N);),
+              #qw(omega(N);),
+              qw(o(T);
+                 [o]delta(N,T);),
+              'int [o]psi(N,T)'),
  GenericTypes => $FLOAT_TYPES,
  Code =>
 ('
@@ -950,14 +950,14 @@ pp_def
 ('hmmviterbiq',
  GenericTypes => $FLOAT_TYPES,
  Pars => join(" ",
-	      qw(a(N,N);
-		 b(N,M);
-		 pi(N);),
-	      qw(o(T);
-		 oq(Q,T);),
-	      '[o]deltaq(Q,T);',
-	      'int [o]psiq(Q,T)',
-	      ),
+              qw(a(N,N);
+                 b(N,M);
+                 pi(N);),
+              qw(o(T);
+                 oq(Q,T);),
+              '[o]deltaq(Q,T);',
+              'indx [o]psiq(Q,T)',
+             ),
  Code =>
 ('
  int qi,qj, i,j, t, o_t;
@@ -1045,7 +1045,7 @@ to do:
 ## Sequence Analysis: Backtrace
 pp_def
 ('hmmpath',
- Pars => q(float+ psi(N,T); int qfinal(); int [o]path(T)),
+ Pars => q(float+ psi(N,T); indx qfinal(); indx [o]path(T)),
  Code =>
 ('
  /*-- Initialize: t==T-1: state_(t)==final() --*/
@@ -1083,7 +1083,7 @@ but also tends to be quite convenient.
 ## Sequence Analysis: Backtrace (constrained)
 pp_def
 ('hmmpathq',
- Pars => q(int oq(Q,T); float+ psiq(Q,T); int qfinalq(); int [o]path(T)),
+ Pars => q(indx oq(Q,T); float+ psiq(Q,T); indx qfinalq(); indx [o]path(T)),
  Code =>
 ('
  /*-- Initialize: t==T-1: state_(t)==final() --*/

--- a/HMM.pd
+++ b/HMM.pd
@@ -196,6 +196,7 @@ pp_def('logzero',
 ## log addition: logadd(a,b) = log(exp(a)+exp(b))
 pp_def('logadd',
        Pars => 'a(); b(); [o]c()',
+       GenericTypes => [qw(F D)],
        Inplace=>['a'], ##-- can run inplace on a()
        Code => '$c() = logadd($a(),$b());',
        Doc => 'Computes $c() = log(exp($a()) + exp($b())), should be more stable.',
@@ -205,6 +206,7 @@ pp_def('logadd',
 ## log subtraction: logdiff(a,b) = log(exp(max(a,b))-exp(min(a,b)))
 pp_def('logdiff',
        Pars => 'a(); b(); [o]c()',
+       GenericTypes => [qw(F D)],
        Inplace=>['a'], ##-- can run inplace on a()
        Code => '$c() = logdiff($a(),$b());',
        Doc => 'Computes log symmetric difference c = log(exp(max(a,b)) - exp(min(a,b))), may be more stable.',
@@ -215,6 +217,7 @@ pp_def('logdiff',
 ## log sum: logsumover(a) = log(sumover(exp(a)))
 pp_def('logsumover',
        Pars => 'a(n); [o]b()',
+       GenericTypes => [qw(F D)],
        Code => (join(" ",
 		     'double sum=LOG_ZERO;',
 		     'loop (n) %{ sum = logadd($a(),sum); %}',
@@ -239,6 +242,7 @@ EOPM
 pp_def
 ('hmmfw',
  Pars => 'a(N,N); b(N,M); pi(N);  o(T);  [o]alpha(N,T)',
+ GenericTypes => [qw(F D)],
  Code =>
 ('
  /*-- Initialize: t==0 --*/
@@ -324,6 +328,7 @@ pp_add_exported('','hmmalpha');
 pp_def
 ('hmmfwq',
  Pars => 'a(N,N); b(N,M); pi(N);  o(T); oq(Q,T);  [o]alphaq(Q,T)',
+ GenericTypes => [qw(F D)],
  Code =>
 ('
  /*-- Initialize: t==0 --*/
@@ -421,6 +426,7 @@ pp_add_exported('','hmmalphaq');
 pp_def
 #@l=
 ('hmmbw',
+ GenericTypes => [qw(F D)],
  Pars => 'a(N,N); b(N,M); omega(N); o(T); [o]beta(N,T)',
  Code =>
 ('
@@ -494,6 +500,7 @@ pp_add_exported('','hmmbeta');
 pp_def
 #@l=
 ('hmmbwq',
+ GenericTypes => [qw(F D)],
  Pars => 'a(N,N); b(N,M); omega(N); o(T); oq(Q,T); [o]betaq(Q,T)',
  Code =>
 ('
@@ -610,6 +617,7 @@ pp_add_exported('', 'hmmexpect0');
 ## Parameter Estimation: Expect
 pp_def
 ('hmmexpect',
+ GenericTypes => [qw(F D)],
  Pars => join(" ",
 	      qw(a(N,N);
 		 b(N,M);
@@ -684,6 +692,7 @@ Can safely be called sequentially for incremental reestimation.
 ## Parameter Estimation: Expect (constrained)
 pp_def
 ('hmmexpectq',
+ GenericTypes => [qw(F D)],
  Pars => join(" ",
 	      qw(a(N,N);
 		 b(N,M);
@@ -830,12 +839,13 @@ pp_def
 ('hmmviterbi',
  Pars => join(" ",
 	      qw(a(N,N);
-		 b(N,M);
+             b(N,M);
 		 pi(N);),
 	      #qw(omega(N);),
 	      qw(o(T);
 		   [o]delta(N,T);),
 	      'int [o]psi(N,T)'),
+ GenericTypes => [qw(F D)],
  Code =>
 ('
  int i,j, t, o_t;
@@ -935,6 +945,7 @@ to do:
 ## Sequence Analysis: Viterbi (constrained)
 pp_def
 ('hmmviterbiq',
+ GenericTypes => [qw(F D)],
  Pars => join(" ",
 	      qw(a(N,N);
 		 b(N,M);
@@ -1031,7 +1042,7 @@ to do:
 ## Sequence Analysis: Backtrace
 pp_def
 ('hmmpath',
- Pars => q(psi(N,T); int qfinal(); int [o]path(T)),
+ Pars => q(float+ psi(N,T); int qfinal(); int [o]path(T)),
  Code =>
 ('
  /*-- Initialize: t==T-1: state_(t)==final() --*/
@@ -1069,7 +1080,7 @@ but also tends to be quite convenient.
 ## Sequence Analysis: Backtrace (constrained)
 pp_def
 ('hmmpathq',
- Pars => q(oq(Q,T); psiq(Q,T); int qfinalq(); int [o]path(T)),
+ Pars => q(int oq(Q,T); float+ psiq(Q,T); int qfinalq(); int [o]path(T)),
  Code =>
 ('
  /*-- Initialize: t==T-1: state_(t)==final() --*/
@@ -1233,7 +1244,7 @@ Bryan Jurish E<lt>moocow@cpan.orgE<gt>
 
 =head2 Copyright Policy
 
-Copyright (C) 2005, 2006, 2008, 2011 by Bryan Jurish. All rights reserved.
+Copyright (C) 2005-2023 by Bryan Jurish. All rights reserved.
 
 This package is free software, and entirely without warranty.
 You may redistribute it and/or modify it under the same terms

--- a/HMM.pd
+++ b/HMM.pd
@@ -13,6 +13,9 @@ use version;
 our $pdl_version       = version->parse($PDL::VERSION);
 our $propagate_badflag = $pdl_version >= '2.008' ? "propagate_badflag" : "propogate_badflag";
 
+##-- floating-point types
+my $FLOAT_TYPES = [qw(F D LD)];
+
 ##------------------------------------------------------
 ## pm additions
 pp_addpm({At=>'Top'},<<'EOPM');
@@ -196,7 +199,7 @@ pp_def('logzero',
 ## log addition: logadd(a,b) = log(exp(a)+exp(b))
 pp_def('logadd',
        Pars => 'a(); b(); [o]c()',
-       GenericTypes => [qw(F D)],
+       GenericTypes => $FLOAT_TYPES,
        Inplace=>['a'], ##-- can run inplace on a()
        Code => '$c() = logadd($a(),$b());',
        Doc => 'Computes $c() = log(exp($a()) + exp($b())), should be more stable.',
@@ -206,7 +209,7 @@ pp_def('logadd',
 ## log subtraction: logdiff(a,b) = log(exp(max(a,b))-exp(min(a,b)))
 pp_def('logdiff',
        Pars => 'a(); b(); [o]c()',
-       GenericTypes => [qw(F D)],
+       GenericTypes => $FLOAT_TYPES,
        Inplace=>['a'], ##-- can run inplace on a()
        Code => '$c() = logdiff($a(),$b());',
        Doc => 'Computes log symmetric difference c = log(exp(max(a,b)) - exp(min(a,b))), may be more stable.',
@@ -217,7 +220,7 @@ pp_def('logdiff',
 ## log sum: logsumover(a) = log(sumover(exp(a)))
 pp_def('logsumover',
        Pars => 'a(n); [o]b()',
-       GenericTypes => [qw(F D)],
+       GenericTypes => $FLOAT_TYPES,
        Code => (join(" ",
 		     'double sum=LOG_ZERO;',
 		     'loop (n) %{ sum = logadd($a(),sum); %}',
@@ -242,7 +245,7 @@ EOPM
 pp_def
 ('hmmfw',
  Pars => 'a(N,N); b(N,M); pi(N);  o(T);  [o]alpha(N,T)',
- GenericTypes => [qw(F D)],
+ GenericTypes => $FLOAT_TYPES,
  Code =>
 ('
  /*-- Initialize: t==0 --*/
@@ -328,7 +331,7 @@ pp_add_exported('','hmmalpha');
 pp_def
 ('hmmfwq',
  Pars => 'a(N,N); b(N,M); pi(N);  o(T); oq(Q,T);  [o]alphaq(Q,T)',
- GenericTypes => [qw(F D)],
+ GenericTypes => $FLOAT_TYPES,
  Code =>
 ('
  /*-- Initialize: t==0 --*/
@@ -426,7 +429,7 @@ pp_add_exported('','hmmalphaq');
 pp_def
 #@l=
 ('hmmbw',
- GenericTypes => [qw(F D)],
+ GenericTypes => $FLOAT_TYPES,
  Pars => 'a(N,N); b(N,M); omega(N); o(T); [o]beta(N,T)',
  Code =>
 ('
@@ -500,7 +503,7 @@ pp_add_exported('','hmmbeta');
 pp_def
 #@l=
 ('hmmbwq',
- GenericTypes => [qw(F D)],
+ GenericTypes => $FLOAT_TYPES,
  Pars => 'a(N,N); b(N,M); omega(N); o(T); oq(Q,T); [o]betaq(Q,T)',
  Code =>
 ('
@@ -617,7 +620,7 @@ pp_add_exported('', 'hmmexpect0');
 ## Parameter Estimation: Expect
 pp_def
 ('hmmexpect',
- GenericTypes => [qw(F D)],
+ GenericTypes => $FLOAT_TYPES,
  Pars => join(" ",
 	      qw(a(N,N);
 		 b(N,M);
@@ -692,7 +695,7 @@ Can safely be called sequentially for incremental reestimation.
 ## Parameter Estimation: Expect (constrained)
 pp_def
 ('hmmexpectq',
- GenericTypes => [qw(F D)],
+ GenericTypes => $FLOAT_TYPES,
  Pars => join(" ",
 	      qw(a(N,N);
 		 b(N,M);
@@ -845,7 +848,7 @@ pp_def
 	      qw(o(T);
 		   [o]delta(N,T);),
 	      'int [o]psi(N,T)'),
- GenericTypes => [qw(F D)],
+ GenericTypes => $FLOAT_TYPES,
  Code =>
 ('
  int i,j, t, o_t;
@@ -945,7 +948,7 @@ to do:
 ## Sequence Analysis: Viterbi (constrained)
 pp_def
 ('hmmviterbiq',
- GenericTypes => [qw(F D)],
+ GenericTypes => $FLOAT_TYPES,
  Pars => join(" ",
 	      qw(a(N,N);
 		 b(N,M);

--- a/HMM.pd
+++ b/HMM.pd
@@ -14,9 +14,9 @@ our $pdl_version       = version->parse($PDL::VERSION);
 our $propagate_badflag = $pdl_version >= '2.008' ? "propagate_badflag" : "propogate_badflag";
 
 ##-- floating-point types
-## PDL v2.082 doesn't like LD here
+## PDL v2.082 doesn't like LD here (so we use 'E' instead)
 ##  - t/03_baum.t crashes at line 115 with `PP INTERNAL ERROR in logadd: unhandled datatype(11)`
-my $FLOAT_TYPES = [qw(F D)]; #LD
+my $FLOAT_TYPES = [qw(F D E)];
 
 ##------------------------------------------------------
 ## pm additions

--- a/HMM.pd
+++ b/HMM.pd
@@ -14,7 +14,9 @@ our $pdl_version       = version->parse($PDL::VERSION);
 our $propagate_badflag = $pdl_version >= '2.008' ? "propagate_badflag" : "propogate_badflag";
 
 ##-- floating-point types
-my $FLOAT_TYPES = [qw(F D LD)];
+## PDL v2.082 doesn't like LD here
+##  - t/03_baum.t crashes at line 115 with `PP INTERNAL ERROR in logadd: unhandled datatype(11)`
+my $FLOAT_TYPES = [qw(F D)]; #LD
 
 ##------------------------------------------------------
 ## pm additions

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,9 +8,9 @@ $package  = ["HMM.pd",HMM,PDL::HMM];
 %hash = pdlmaker_init($package);
 
 my %prereq = (
-	      PDL=>0,
-	      'Test::More'=>0,
-	     );
+              PDL => 2.082,
+              'Test::More'=>0,
+             );
 
 $hash{AUTHOR} = 'Bryan Jurish';
 $hash{ABSTRACT} = 'PDL Hidden Markov Model utilities';


### PR DESCRIPTION
@mohawk2 continuing the discussion from https://github.com/moocow-the-bovine/PDL-HMM/pull/3 :

- setting `LOG_ZERO` to `-1.0/0.0` breaks lots of HMM tests (with `NaN`s probably resulting from perl-side divisions)
  - there doesn't seem to be an IEEE-compliant constant in `math.h` for that either ... huh.

- added `GenericTypes => [qw(F D)]` where apprpropriate

- nb: including `LD` in the `GenericTypes` array would break at least 1 test:
```
t/03_baum.t .. 
1..11
loaded /local/home/moocow/work/diss/perl/PDL-HMM/t/common.plt
PP INTERNAL ERROR in logadd: unhandled datatype(11), only handles (FD)! PLEASE MAKE A BUG REPORT
 at t/03_baum.t line 49.
	main::emE() called at t/03_baum.t line 115
# Looks like your test exited with 34 before it could output anything.
Dubious, test returned 34 (wstat 8704, 0x2200)
```

I realize this solution is not ideal, but it's the best I can offer in terms of bang-for-buck at the moment.  I'd appreciate your thoughts (and/or concrete suggestions).